### PR TITLE
refactor - Student 엔티티에 JPA 어노테이션 추가

### DIFF
--- a/src/main/java/org/ccs/app/core/studunt/domain/Student.java
+++ b/src/main/java/org/ccs/app/core/studunt/domain/Student.java
@@ -1,12 +1,36 @@
 package org.ccs.app.core.studunt.domain;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.ccs.app.core.user.domain.User;
 
 import java.time.LocalDateTime;
 
+@NoArgsConstructor
+@Entity
+@Table(name = "ccs_student")
+@Getter @Setter
 public class Student {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "ccs_user_id")
     private User student;
+
+    // Audit 분리
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    /*
+    @Embedded
+    private Audit audit;
+
+    @ManyToOne
+    @JoinColumn(name = "ccs_section_id")
+    private Section section;
+     */
 }

--- a/src/main/java/org/ccs/app/core/user/domain/User.java
+++ b/src/main/java/org/ccs/app/core/user/domain/User.java
@@ -17,7 +17,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 @NoArgsConstructor
 @Entity
-@Table(name = "css_user")
+@Table(name = "ccs_user")
 @DynamicInsert
 @DynamicUpdate
 @Getter @ToString


### PR DESCRIPTION
### 내용
- Student 클래스에 데이터베이스 엔티티 매핑을 위한 JPA 어노테이션을 추가했습니다.
- 현재 Audit과 Section 관계를 주석 처리하였고, 추후 별도로 리팩토링할 계획입니다.

### 질문
- [x] SQL문 관련해서 `@DynamicInsert, @DynamicUpdate` 어노테이션이 필요한 것인지 궁금합니다. "Student 필드가 자주 변경되지 않을 거 같아서 일단 사용하지 않았습니다."
- [x] `@ToString`의 경우 로그를 확인하기 위해 모든 엔티티에 필요한 것인지 궁금합니다. "일단 사용하지 않았습니다."

### 기타
- ~~rename 커밋 부분은 jwt브랜치를 받아왔더니 작업 내용까지 같이 받아와졌습니다.~~