### PR TITLE
[ feature ] User클래스 '@Column'으로 컬럼명 명시

### DIFF
--- a/src/main/java/org/ccs/app/core/user/domain/User.java
+++ b/src/main/java/org/ccs/app/core/user/domain/User.java
@@ -1,10 +1,7 @@
 package org.ccs.app.core.user.domain;
 
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -24,22 +21,51 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 public class User {
     @Id
     @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id")
     private Long id;
+
+    @Column(name = "type")
     private UserType type;
+
+    @Column(name = "name")
     private String name;
+
+    @Column(name = "parish")
     private Integer parish; // 교구
+
+    @Column(name = "cell_group")
     private Integer cellGroup; //구역
+
+    @Column(name = "fellowship_group")
     private FellowShipGroup fellowShipGroup; // 회별
+
+    @Column(name = "gender")
     private Gender gender;
+
+    @Column(name = "zipcode")
     private String zipcode; // 우편
+
+    @Column(name = "address")
     private String address;
+
+    @Column(name = "phone_number")
     private String phoneNumber;
+
+    @Column(name = "profile_image")
     private String profileImage;
 
+
+    @Column(name = "state")
     private Boolean state;
+
+    @Column(name = "reason")
     private String reason;
 
     // fixme : Audit으로 분리할 것
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     jpa:
       hibernate:
-        ddl-auto: create  # ?????? ?? ??? ???? drop?? ?? ????.
+        ddl-auto: none  # | update | none | create | create-drop // TODO: 공부할 것
       properties:
         hibernate:
           format_sql: true


### PR DESCRIPTION
### **내용**
- User클래스 '@Column'으로 컬럼명을 명시하였습니다.

### **DB 설계 내용**
- `id`를 pk로 지정
- `phone_number` 휴대폰 번호 기준 varchar(11)로 설정
- `parish, cell_group` 구역 및 교구 숫자만 입력될 것이라 생각하여 int 사용
- `fellowship_group` MOTHER, FATHER 기준 varchar(6)
- `gender` M, F 사용 고려하여 varchar(1)
- `zipcode` 세종특별자치시 고려하여 varchar(7)
- `address` 주소 넉넉잡아 varchar(60)
- `type` 교사 학생 영단어 기준 varchar(7)
- `state` 상태는 불리언타입(tinyint) 0,1 사용고려 tinyint(1)
- `reason` 넉넉잡아 varchar(7)
- `created_at, updated_at` 자동 갱신 기능이 적합하다 생각하여 timestamp 사용
- `profile_image` 이미지를 url로 불러왔을 경우 아직 url 길이를 모르므로 varchar(255)로 두었습니다.

### **기타**
- 유저_롤/유저_어카운트 테이블 설계 진행 예정
- 해당 브랜치에서 ddl-none으로 직접 수정 (각 설정의 차이 공부 예정)