### PR TITLE
간다한 오타 수정

### DIFF
--- a/src/main/java/org/ccs/app/core/academic/domain/AcademicSchedule.java
+++ b/src/main/java/org/ccs/app/core/academic/domain/AcademicSchedule.java
@@ -21,7 +21,7 @@ public class AcademicSchedule {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    @Column(name = "year")
+    @Column(name = "academic_year")
     private Integer year;
 
     @Column(name = "closed")
@@ -33,6 +33,6 @@ public class AcademicSchedule {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    @Column(name = "updated at")
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/ccs/app/entrypoints/academic/service/AcademicScheduleService.java
+++ b/src/main/java/org/ccs/app/entrypoints/academic/service/AcademicScheduleService.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface AcademicScheduleService {
 
-    List<LocalDate> generateAcademiSchedules(CreateAcademicScheduleRequest request);
+    List<LocalDate> generateAcademicSchedules(CreateAcademicScheduleRequest request);
 }

--- a/src/main/java/org/ccs/app/entrypoints/academic/service/AcademicScheduleServiceImpl.java
+++ b/src/main/java/org/ccs/app/entrypoints/academic/service/AcademicScheduleServiceImpl.java
@@ -14,7 +14,7 @@ public class AcademicScheduleServiceImpl implements AcademicScheduleService {
     private final GenerateAcademicScheduleUsecase generateAcademicScheduleUsecase;
 
     @Override
-    public List<LocalDate> generateAcademiSchedules(CreateAcademicScheduleRequest request) {
+    public List<LocalDate> generateAcademicSchedules(CreateAcademicScheduleRequest request) {
         return generateAcademicScheduleUsecase.generate(request.targetDate());
     }
 }


### PR DESCRIPTION
- rename: 오타로 인한 변경 (AcademicSchedule)
- rename: DB 예약어등의 이유로 컬럼명 변경