### PR TITLE
feat: 유저 어카운트 테이블 설계 및 엔티티 설정

### DIFF
--- a/src/main/java/org/ccs/app/core/user/domain/UserAccount.java
+++ b/src/main/java/org/ccs/app/core/user/domain/UserAccount.java
@@ -1,16 +1,44 @@
 package org.ccs.app.core.user.domain;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.ccs.app.core.share.domain.BaseCreatedAndUpdatedDateTime;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
 import java.time.LocalDateTime;
 import java.util.List;
-
-public class UserAccount {
+@Entity
+@Table(name = "ccs_user_account")
+@NoArgsConstructor
+@DynamicUpdate
+@DynamicInsert
+@Getter @ToString
+public class UserAccount extends BaseCreatedAndUpdatedDateTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "email")
     private String email; // login id
-    private String password; //
+
+    @Column(name = "password")
+    private String password; // login pw
+
+    @OneToMany(mappedBy = "account")
     private List<UserRole> roles;
+
+    @Column(name = "login_failure_count")
     private Integer loginFailureCount;
+
+    @Column(name = "status")
     private AccountStatus status;
+
+    @Column(name = "last_access_dt")
     private LocalDateTime lastAccessAt;
+
+    @Column(name = "password_changed_dt")
     private LocalDateTime passwordChangedAt;
-    private LocalDateTime updatedAt;
 }


### PR DESCRIPTION
### 내용
- BaseCreatedAndUpdatedDateTime 상속 후 updated_dt 컬럼 제거
- dev에 머지 후 유저 롤 클래스의 `@ManyToOne` 주석 제거 예정입니다.