### PR TITLE
로그인 컨트롤러와 서비스 리팩토링 및 리프레시 토큰 기능 추가

### DIFF
--- a/src/main/java/org/ccs/app/core/security/JwtTokenProvider.java
+++ b/src/main/java/org/ccs/app/core/security/JwtTokenProvider.java
@@ -18,6 +18,9 @@ public class JwtTokenProvider {
     @Value("${jwt.expiration-ms}")
     private int jwtExpirationInMs;
 
+    @Value("${jwt.refresh-expiration-ms}")
+    private int refreshExpirationInMs;
+
     // 사용자 ID를 기반으로 JWT 토큰을 생성
     public String generateToken(Long userId) {
         Date now = new Date();
@@ -30,5 +33,17 @@ public class JwtTokenProvider {
                 .setExpiration(expiryDate) // 만료시간 1시간
                 .signWith(SignatureAlgorithm.HS512, jwtSecret) // 토큰 서명
                 .compact(); // JWT 토큰을 문자열로 압축하여 반환
+    }
+
+    public String generateRefreshToken(Long userId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + refreshExpirationInMs);
+
+        return Jwts.builder()
+                .setSubject(Long.toString(userId))
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(SignatureAlgorithm.HS512, jwtSecret)
+                .compact();
     }
 }

--- a/src/main/java/org/ccs/app/entrypoints/login/controller/LoginController.java
+++ b/src/main/java/org/ccs/app/entrypoints/login/controller/LoginController.java
@@ -19,9 +19,8 @@ public class LoginController {
     @PostMapping("/login")
     public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
         try {
-            String jwt = loginService.authenticate(loginRequest);
-            String refreshToken = loginService.createRefreshToken(loginRequest); // 리프레시 토큰 생성
-            return ResponseEntity.ok(new JwtAuthenticationResponse(jwt, refreshToken));
+            JwtAuthenticationResponse response = loginService.authenticateAndCreateTokens(loginRequest);
+            return ResponseEntity.ok(response);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         } catch (Exception e) {

--- a/src/main/java/org/ccs/app/entrypoints/login/controller/LoginController.java
+++ b/src/main/java/org/ccs/app/entrypoints/login/controller/LoginController.java
@@ -17,14 +17,8 @@ public class LoginController {
     private LoginService loginService;
 
     @PostMapping("/login")
-    public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
-        try {
-            JwtAuthenticationResponse response = loginService.authenticateAndCreateTokens(loginRequest);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().body("An error occurred");
-        }
+    public ResponseEntity<JwtAuthenticationResponse> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
+        JwtAuthenticationResponse response = loginService.authenticateAndCreateTokens(loginRequest);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/ccs/app/entrypoints/login/controller/LoginController.java
+++ b/src/main/java/org/ccs/app/entrypoints/login/controller/LoginController.java
@@ -20,7 +20,8 @@ public class LoginController {
     public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
         try {
             String jwt = loginService.authenticate(loginRequest);
-            return ResponseEntity.ok(new JwtAuthenticationResponse(jwt));
+            String refreshToken = loginService.createRefreshToken(loginRequest); // 리프레시 토큰 생성
+            return ResponseEntity.ok(new JwtAuthenticationResponse(jwt, refreshToken));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         } catch (Exception e) {

--- a/src/main/java/org/ccs/app/entrypoints/login/model/JwtAuthenticationResponse.java
+++ b/src/main/java/org/ccs/app/entrypoints/login/model/JwtAuthenticationResponse.java
@@ -9,4 +9,8 @@ public class JwtAuthenticationResponse {
     private String accessToken;
     private String tokenType = "Bearer";
     private Long expiresIn; // 토큰 만료 시간을 나타내는 필드
+
+    public JwtAuthenticationResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
 }

--- a/src/main/java/org/ccs/app/entrypoints/login/model/JwtAuthenticationResponse.java
+++ b/src/main/java/org/ccs/app/entrypoints/login/model/JwtAuthenticationResponse.java
@@ -7,10 +7,12 @@ import lombok.*;
 @NoArgsConstructor
 public class JwtAuthenticationResponse {
     private String accessToken;
+    private String refreshToken;
     private String tokenType = "Bearer";
-    private Long expiresIn; // 토큰 만료 시간을 나타내는 필드
+    private Long expiresIn;
 
-    public JwtAuthenticationResponse(String accessToken) {
+    public JwtAuthenticationResponse(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/org/ccs/app/entrypoints/login/service/LoginService.java
+++ b/src/main/java/org/ccs/app/entrypoints/login/service/LoginService.java
@@ -28,4 +28,18 @@ public class LoginService {
             throw new IllegalArgumentException("Invalid email or password");
         }
     }
+
+    // 리프레시 토큰 생성 메서드
+    public String createRefreshToken(LoginRequest loginRequest) {
+        // 이메일을 기반으로 사용자 계정 조회
+        UserAccount userAccount = userRepository.findByEmail(loginRequest.getEmail());
+
+        // 사용자 계정이 있는 경우 리프레시 토큰 생성 및 반환
+        if (userAccount != null) {
+            return tokenProvider.generateRefreshToken(userAccount.getId());
+        } else {
+            // 계정이 없는 경우 예외 처리
+            throw new IllegalArgumentException("User not found with email: " + loginRequest.getEmail());
+        }
+    }
 }

--- a/src/main/java/org/ccs/app/entrypoints/login/service/LoginService.java
+++ b/src/main/java/org/ccs/app/entrypoints/login/service/LoginService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.ccs.app.core.security.JwtTokenProvider;
 import org.ccs.app.core.user.domain.UserAccount;
 import org.ccs.app.core.user.infra.repository.UserRepository;
+import org.ccs.app.entrypoints.login.model.JwtAuthenticationResponse;
 import org.ccs.app.entrypoints.login.model.LoginRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -40,6 +41,19 @@ public class LoginService {
         } else {
             // 계정이 없는 경우 예외 처리
             throw new IllegalArgumentException("User not found with email: " + loginRequest.getEmail());
+        }
+    }
+
+    public JwtAuthenticationResponse authenticateAndCreateTokens(LoginRequest loginRequest) {
+        UserAccount userAccount = userRepository.findByEmail(loginRequest.getEmail());
+
+        if (userAccount != null && userAccount.getPassword().equals(loginRequest.getPassword())) {
+            String jwt = tokenProvider.generateToken(userAccount.getId());
+            String refreshToken = tokenProvider.generateRefreshToken(userAccount.getId());
+
+            return new JwtAuthenticationResponse(jwt, refreshToken);
+        } else {
+            throw new IllegalArgumentException("Invalid email or password");
         }
     }
 }

--- a/src/main/java/org/ccs/app/entrypoints/share/controller/BaseRestControllerAdvisor.java
+++ b/src/main/java/org/ccs/app/entrypoints/share/controller/BaseRestControllerAdvisor.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.List;
 
-// TODO: Logging 추가
 
 @RestControllerAdvice
 public class BaseRestControllerAdvisor {
@@ -18,6 +17,7 @@ public class BaseRestControllerAdvisor {
 
     @ExceptionHandler(InvalidRequestParameterException.class)
     public ContentBody<List<ErrorBindings>> handle(InvalidRequestParameterException e) {
+        LOG.warn("Invalid request parameters: {}", e);
         return new ContentBody<>(400, "Bad request.", "", e.getErrors());
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,4 +37,5 @@ logging:
 
 jwt:
   secret: ${JWT_SECRET}
-  expiration-ms: 3600000
+  expiration-ms: 3600000 # 1시간
+  refresh-expiration-ms: 604800000 # 7일


### PR DESCRIPTION
## 변경 사항 요약
- 로그인 컨트롤러의 예외 처리 로직을 BaseRestControllerAdvisor로 이동
- BaseRestControllerAdvisor에 로깅 기능 추가
- 로그인 컨트롤러의 토큰 생성 로직을 서비스 레이어로 이동
- 리프레시 토큰 생성 메서드 및 관련 로직 추가
---
## 상세 변경 내용
### 로그인 컨트롤러 예외 처리 로직 이동
- 컨트롤러에서 try-catch 문을 제거하고 BaseRestControllerAdvisor로 예외 처리 위임
- BaseRestControllerAdvisor에 로깅 기능 추가하여 예외 상황 시 로그 기록

### 토큰 생성 로직 서비스 레이어로 이동
- 로그인 시 토큰 생성 로직을 LoginService로 이동하여 책임 분리 강화
 
### 리프레시 토큰 기능 추가
- JwtAuthenticationResponse에 리프레시 토큰 필드 추가
- LoginService에 리프레시 토큰 생성 메서드 추가
- application.yml에 리프레시 토큰 유효시간 설정 추가