### PR TITLE
aws parameter store 를 사용할 수 있는 환경 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-logging:3.1.0'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.224'
+    //AWS Parameter Store
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.0")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'com.auth0:java-jwt:3.18.1'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'

--- a/src/main/java/org/ccs/app/entrypoints/login/model/JwtAuthenticationResponse.java
+++ b/src/main/java/org/ccs/app/entrypoints/login/model/JwtAuthenticationResponse.java
@@ -1,6 +1,8 @@
 package org.ccs.app.entrypoints.login.model;
 
-import lombok.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -9,4 +11,8 @@ public class JwtAuthenticationResponse {
     private String accessToken;
     private String tokenType = "Bearer";
     private Long expiresIn; // 토큰 만료 시간을 나타내는 필드
+
+    public JwtAuthenticationResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,12 @@
 spring:
+  config:
+    import: aws-parameterstore:/config/ccs/
   thymeleaf:
     cache: false
   datasource:
-    url: jdbc:mysql://pre035.chh5jixw7uel.ap-northeast-2.rds.amazonaws.com:3306/pre35db
-    username: master
-    password: abcd1234
+    url: ${db.url}
+    username: ${db.user}
+    password: ${db.password}
     driver-class-name: com.mysql.cj.jdbc.Driver
     jpa:
       hibernate:
@@ -31,10 +33,15 @@ cloud:
       bucket-name: temp-ccs-files
       pre-signed:
         expiration: 60
+aws:
+  paramstore:
+    enabled: true
+    prefix: /config
+    profile-separator: .
 
 logging:
   config: classpath:logback/logback.xml
 
 jwt:
-  secret: ${JWT_SECRET}
+  secret: ${jwt.secret}
   expiration-ms: 3600000

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,4 +27,3 @@ cloud:
       bucket-name: temp-ccs-files
       pre-signed:
         expiration: 60
-


### PR DESCRIPTION
- aws parameter store 적용
- DB 정보, secret key 정보 parameterstore로 이관 
- JwtAuthenticationResponse 코드 에러 임시 해결

@tjddnjs0102 계속 에러가 있는 코드가 머지되고 있습니다. 
항상 서버 실행 후에 push 하는 습관이 필요합니다. 

해당 PR은 설정 변경으로 바로 머지하겠습니다.
대신 해당 코드에 대해 확인 후 이해는 필요할 것 같습니다. 