### PR TITLE
로그인 서비스 리팩토링

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@
 ## Code Convention
 <hr>
 
+## 메소드
+
+### 네이밍 룰
+
+- 조회시 get과 find의 차이 
+  - get의 경우 반드시 있어야 한다.
+  - find의 경우 있을 수도 있고 없을 수도 있는 경우 사용한다. 
+
 ## Package Structure
 <hr>
 

--- a/src/main/java/org/ccs/app/core/common/exception/NotFoundMenuItemException.java
+++ b/src/main/java/org/ccs/app/core/common/exception/NotFoundMenuItemException.java
@@ -1,7 +1,7 @@
 package org.ccs.app.core.common.exception;
 
-import org.ccs.app.core.share.domain.ErrorCode;
 import org.ccs.app.core.share.exception.BusinessException;
+import org.ccs.app.core.share.exception.ErrorCode;
 
 public class NotFoundMenuItemException extends BusinessException {
 

--- a/src/main/java/org/ccs/app/core/security/JwtTokenProvider.java
+++ b/src/main/java/org/ccs/app/core/security/JwtTokenProvider.java
@@ -22,9 +22,9 @@ public class JwtTokenProvider {
     private int refreshExpirationInMs;
 
     // 사용자 ID를 기반으로 JWT 토큰을 생성
-    public String generateToken(Long userId) {
+    private String generateTokenBase(Long userId, int expirationInMs) {
         Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + jwtExpirationInMs);
+        Date expiryDate = new Date(now.getTime() + expirationInMs);
 
         // JWT 토큰을 생성
         return Jwts.builder()
@@ -35,15 +35,11 @@ public class JwtTokenProvider {
                 .compact(); // JWT 토큰을 문자열로 압축하여 반환
     }
 
-    public String generateRefreshToken(Long userId) {
-        Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + refreshExpirationInMs);
+    public String generateToken(Long userId) {
+        return generateTokenBase(userId, jwtExpirationInMs);
+    }
 
-        return Jwts.builder()
-                .setSubject(Long.toString(userId))
-                .setIssuedAt(now)
-                .setExpiration(expiryDate)
-                .signWith(SignatureAlgorithm.HS512, jwtSecret)
-                .compact();
+    public String generateRefreshToken(Long userId) {
+        return generateTokenBase(userId, refreshExpirationInMs);
     }
 }

--- a/src/main/java/org/ccs/app/core/security/JwtTokenProvider.java
+++ b/src/main/java/org/ccs/app/core/security/JwtTokenProvider.java
@@ -15,10 +15,10 @@ public class JwtTokenProvider {
     @Value("${jwt.secret}")
     private String jwtSecret;
 
-    @Value("${jwt.expiration-ms}")
+    @Value("${jwt.token.access.expiration-ms}")
     private int jwtExpirationInMs;
 
-    @Value("${jwt.refresh-expiration-ms}")
+    @Value("${jwt.token.refresh.expiration-ms}")
     private int refreshExpirationInMs;
 
     // 사용자 ID를 기반으로 JWT 토큰을 생성

--- a/src/main/java/org/ccs/app/core/security/JwtTokenProvider.java
+++ b/src/main/java/org/ccs/app/core/security/JwtTokenProvider.java
@@ -21,18 +21,17 @@ public class JwtTokenProvider {
     @Value("${jwt.token.refresh.expiration-ms}")
     private int refreshExpirationInMs;
 
-    // 사용자 ID를 기반으로 JWT 토큰을 생성
+
     private String generateTokenBase(Long userId, int expirationInMs) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + expirationInMs);
 
-        // JWT 토큰을 생성
         return Jwts.builder()
-                .setSubject(Long.toString(userId)) // 토큰 subject를 사용자 ID로 설정
+                .setSubject(Long.toString(userId))
                 .setIssuedAt(now)
-                .setExpiration(expiryDate) // 만료시간 1시간
-                .signWith(SignatureAlgorithm.HS512, jwtSecret) // 토큰 서명
-                .compact(); // JWT 토큰을 문자열로 압축하여 반환
+                .setExpiration(expiryDate)
+                .signWith(SignatureAlgorithm.HS512, jwtSecret)
+                .compact();
     }
 
     public String generateToken(Long userId) {

--- a/src/main/java/org/ccs/app/core/share/exception/ErrorCode.java
+++ b/src/main/java/org/ccs/app/core/share/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package org.ccs.app.core.share.domain;
+package org.ccs.app.core.share.exception;
 
 import lombok.Getter;
 
@@ -10,6 +10,12 @@ import lombok.Getter;
  *  (계속추가)
  */
 public enum ErrorCode {
+    // TODO : message 에 다국어 적용
+    UNKNOWN(100, ""),
+
+    UNAUTHORIZED_ACCESS(101, "사용자 인증에 실패하였습니다."),
+    NO_SUCH_USER(102, "로그인 아이디를 찾을 수 없습니다."),
+    INCORRECT_PASSWORD(102, "로그인 패스워드가 일치하지 않습니다."),
 
     NOT_FOUND_MENU(1000, ""),
     ;

--- a/src/main/java/org/ccs/app/core/share/exception/ErrorCodeCategory.java
+++ b/src/main/java/org/ccs/app/core/share/exception/ErrorCodeCategory.java
@@ -1,4 +1,4 @@
-package org.ccs.app.core.share.domain;
+package org.ccs.app.core.share.exception;
 
 public enum ErrorCodeCategory {
 

--- a/src/main/java/org/ccs/app/core/share/exception/auth/NoSuchUserException.java
+++ b/src/main/java/org/ccs/app/core/share/exception/auth/NoSuchUserException.java
@@ -1,0 +1,10 @@
+package org.ccs.app.core.share.exception.auth;
+
+import org.ccs.app.core.share.exception.ErrorCode;
+
+public class NoSuchUserException extends UnauthorizedAccessException {
+
+    public NoSuchUserException() {
+        super(ErrorCode.NO_SUCH_USER);
+    }
+}

--- a/src/main/java/org/ccs/app/core/share/exception/auth/PasswordNotMatchException.java
+++ b/src/main/java/org/ccs/app/core/share/exception/auth/PasswordNotMatchException.java
@@ -1,0 +1,10 @@
+package org.ccs.app.core.share.exception.auth;
+
+import org.ccs.app.core.share.exception.ErrorCode;
+
+public class PasswordNotMatchException extends UnauthorizedAccessException {
+
+    public PasswordNotMatchException() {
+        super(ErrorCode.INCORRECT_PASSWORD);
+    }
+}

--- a/src/main/java/org/ccs/app/core/share/exception/auth/UnauthorizedAccessException.java
+++ b/src/main/java/org/ccs/app/core/share/exception/auth/UnauthorizedAccessException.java
@@ -1,0 +1,18 @@
+package org.ccs.app.core.share.exception.auth;
+
+import org.ccs.app.core.share.exception.BusinessException;
+import org.ccs.app.core.share.exception.ErrorCode;
+
+public class UnauthorizedAccessException extends BusinessException {
+    public UnauthorizedAccessException(int code, String message) {
+        super(code, message);
+    }
+
+    public UnauthorizedAccessException(ErrorCode errorCode) {
+        this(errorCode.getCode(), errorCode.getMessage());
+    }
+
+    public UnauthorizedAccessException() {
+        this(ErrorCode.UNAUTHORIZED_ACCESS);
+    }
+}

--- a/src/main/java/org/ccs/app/core/user/application/AuthenticationApplication.java
+++ b/src/main/java/org/ccs/app/core/user/application/AuthenticationApplication.java
@@ -1,0 +1,35 @@
+package org.ccs.app.core.user.application;
+
+import lombok.RequiredArgsConstructor;
+import org.ccs.app.core.share.exception.auth.NoSuchUserException;
+import org.ccs.app.core.share.exception.auth.PasswordNotMatchException;
+import org.ccs.app.core.user.application.usecase.LoginUsecase;
+import org.ccs.app.core.user.application.usecase.LogoutUsecase;
+import org.ccs.app.core.user.domain.UserAccount;
+import org.ccs.app.core.user.infra.repository.UserAccountRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class AuthenticationApplication implements LoginUsecase, LogoutUsecase {
+    private final UserAccountRepository userAccountRepository;
+
+    @Transactional(noRollbackFor = PasswordNotMatchException.class) // 엄청중요함!! 이것이 어떤 역할인지 공부하세요!!
+    @Override
+    public UserAccount login(String id, String password) {
+        UserAccount account = getUserByEmail(id);
+        account.confirmPassword(password);
+        return account;
+    }
+
+    @Override
+    public void logout() {
+        // FIXME: 나중에 구현할 기능
+    }
+
+    // README에 getXXX(), findXXXX() 메소드의 차이를 적어두었습니다.
+    private UserAccount getUserByEmail(String email) {
+        return userAccountRepository.findByEmail(email).orElseThrow(NoSuchUserException::new);
+    }
+}

--- a/src/main/java/org/ccs/app/core/user/application/usecase/LoginUsecase.java
+++ b/src/main/java/org/ccs/app/core/user/application/usecase/LoginUsecase.java
@@ -1,0 +1,8 @@
+package org.ccs.app.core.user.application.usecase;
+
+import org.ccs.app.core.user.domain.UserAccount;
+
+public interface LoginUsecase {
+
+    UserAccount login(String id, String password);
+}

--- a/src/main/java/org/ccs/app/core/user/application/usecase/LogoutUsecase.java
+++ b/src/main/java/org/ccs/app/core/user/application/usecase/LogoutUsecase.java
@@ -1,0 +1,6 @@
+package org.ccs.app.core.user.application.usecase;
+
+public interface LogoutUsecase {
+
+    void logout();
+}

--- a/src/main/java/org/ccs/app/core/user/infra/repository/UserAccountRepository.java
+++ b/src/main/java/org/ccs/app/core/user/infra/repository/UserAccountRepository.java
@@ -1,0 +1,12 @@
+package org.ccs.app.core.user.infra.repository;
+
+import org.ccs.app.core.user.domain.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+    Optional<UserAccount> findByEmail(String email);
+}

--- a/src/main/java/org/ccs/app/core/user/infra/repository/UserRepository.java
+++ b/src/main/java/org/ccs/app/core/user/infra/repository/UserRepository.java
@@ -1,16 +1,10 @@
 package org.ccs.app.core.user.infra.repository;
 
 import org.ccs.app.core.user.domain.User;
-import org.ccs.app.core.user.domain.UserAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-/**
- * 메소드 쿼리를 정의한다.
- */
-
-// TODO : DB 연결 후 수정
 @Repository
-public interface UserRepository extends JpaRepository<UserAccount, Long>, UserCustomRepository {
-    UserAccount findByEmail(String email);
+public interface UserRepository extends JpaRepository<User, Long>, UserCustomRepository {
+
 }

--- a/src/main/java/org/ccs/app/entrypoints/login/service/LoginService.java
+++ b/src/main/java/org/ccs/app/entrypoints/login/service/LoginService.java
@@ -16,9 +16,13 @@ public class LoginService {
     private final UserRepository userRepository;
     private final JwtTokenProvider tokenProvider;
 
+    private UserAccount findUserByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
     public String authenticate(LoginRequest loginRequest) {
         // 이메일을 기반으로 사용자 계정 조회
-        UserAccount userAccount = userRepository.findByEmail(loginRequest.getEmail());
+        UserAccount userAccount = findUserByEmail(loginRequest.getEmail());
 
         // 사용자 계정이 존재하고 비밀번호가 일치하는지 확인
         if (userAccount != null && userAccount.getPassword().equals(loginRequest.getPassword())) {
@@ -33,7 +37,7 @@ public class LoginService {
     // 리프레시 토큰 생성 메서드
     public String createRefreshToken(LoginRequest loginRequest) {
         // 이메일을 기반으로 사용자 계정 조회
-        UserAccount userAccount = userRepository.findByEmail(loginRequest.getEmail());
+        UserAccount userAccount = findUserByEmail(loginRequest.getEmail());
 
         // 사용자 계정이 있는 경우 리프레시 토큰 생성 및 반환
         if (userAccount != null) {
@@ -45,7 +49,7 @@ public class LoginService {
     }
 
     public JwtAuthenticationResponse authenticateAndCreateTokens(LoginRequest loginRequest) {
-        UserAccount userAccount = userRepository.findByEmail(loginRequest.getEmail());
+        UserAccount userAccount = findUserByEmail(loginRequest.getEmail());
 
         if (userAccount != null && userAccount.getPassword().equals(loginRequest.getPassword())) {
             String jwt = tokenProvider.generateToken(userAccount.getId());

--- a/src/main/java/org/ccs/app/entrypoints/login/service/LoginService.java
+++ b/src/main/java/org/ccs/app/entrypoints/login/service/LoginService.java
@@ -12,7 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-@RequiredArgsConstructor // final 필드에 대한 생성자 자동으로 생성
+@RequiredArgsConstructor
 @Service
 public class LoginService {
     private final Logger log = LoggerFactory.getLogger(LoginService.class);
@@ -28,16 +28,9 @@ public class LoginService {
 
     // 리프레시 토큰 생성 메서드
     public String createRefreshToken(LoginRequest loginRequest) {
-        // 이메일을 기반으로 사용자 계정 조회
-        UserAccount userAccount = getUserByEmail(loginRequest.getEmail());
-
-        // 사용자 계정이 있는 경우 리프레시 토큰 생성 및 반환
-        if (userAccount != null) {
-            return tokenProvider.generateRefreshToken(userAccount.getId());
-        } else {
-            // 계정이 없는 경우 예외 처리
-            throw new IllegalArgumentException("User not found with email: " + loginRequest.getEmail());
-        }
+        UserAccount account = loginUsecase.login(loginRequest.getEmail(), loginRequest.getPassword());
+        log.debug("[refresh token created] account: {}", account);
+        return tokenProvider.generateRefreshToken(account.getId());
     }
 
     public JwtAuthenticationResponse authenticateAndCreateTokens(LoginRequest loginRequest) {
@@ -53,7 +46,6 @@ public class LoginService {
         }
     }
 
-    // README에 get,find의 차이점을 적어두었습니다.
     private UserAccount getUserByEmail(String email) {
         return userAccountRepository.findByEmail(email)
                 .orElseThrow(NoSuchUserException::new);

--- a/src/main/java/org/ccs/app/entrypoints/login/service/LoginService.java
+++ b/src/main/java/org/ccs/app/entrypoints/login/service/LoginService.java
@@ -34,20 +34,10 @@ public class LoginService {
     }
 
     public JwtAuthenticationResponse authenticateAndCreateTokens(LoginRequest loginRequest) {
-        UserAccount userAccount = getUserByEmail(loginRequest.getEmail());
+        UserAccount account = loginUsecase.login(loginRequest.getEmail(), loginRequest.getPassword());
+        String jwt = tokenProvider.generateToken(account.getId());
+        String refreshToken = tokenProvider.generateRefreshToken(account.getId());
 
-        if (userAccount != null && userAccount.getPassword().equals(loginRequest.getPassword())) {
-            String jwt = tokenProvider.generateToken(userAccount.getId());
-            String refreshToken = tokenProvider.generateRefreshToken(userAccount.getId());
-
-            return new JwtAuthenticationResponse(jwt, refreshToken);
-        } else {
-            throw new IllegalArgumentException("Invalid email or password");
-        }
-    }
-
-    private UserAccount getUserByEmail(String email) {
-        return userAccountRepository.findByEmail(email)
-                .orElseThrow(NoSuchUserException::new);
+        return new JwtAuthenticationResponse(jwt, refreshToken);
     }
 }

--- a/src/main/java/org/ccs/app/entrypoints/login/service/LoginService.java
+++ b/src/main/java/org/ccs/app/entrypoints/login/service/LoginService.java
@@ -21,29 +21,22 @@ public class LoginService {
     }
 
     public String authenticate(LoginRequest loginRequest) {
-        // 이메일을 기반으로 사용자 계정 조회
         UserAccount userAccount = findUserByEmail(loginRequest.getEmail());
 
-        // 사용자 계정이 존재하고 비밀번호가 일치하는지 확인
         if (userAccount != null && userAccount.getPassword().equals(loginRequest.getPassword())) {
-            // JWT 토큰 생성 및 반환
             return tokenProvider.generateToken(userAccount.getId());
         } else {
-            // 잘못된 이메일 또는 비밀번호에 대한 예외 처리
             throw new IllegalArgumentException("Invalid email or password");
         }
     }
 
     // 리프레시 토큰 생성 메서드
     public String createRefreshToken(LoginRequest loginRequest) {
-        // 이메일을 기반으로 사용자 계정 조회
         UserAccount userAccount = findUserByEmail(loginRequest.getEmail());
 
-        // 사용자 계정이 있는 경우 리프레시 토큰 생성 및 반환
         if (userAccount != null) {
             return tokenProvider.generateRefreshToken(userAccount.getId());
         } else {
-            // 계정이 없는 경우 예외 처리
             throw new IllegalArgumentException("User not found with email: " + loginRequest.getEmail());
         }
     }

--- a/src/main/java/org/ccs/app/entrypoints/share/controller/BaseRestControllerAdvisor.java
+++ b/src/main/java/org/ccs/app/entrypoints/share/controller/BaseRestControllerAdvisor.java
@@ -17,7 +17,7 @@ public class BaseRestControllerAdvisor {
 
     @ExceptionHandler(InvalidRequestParameterException.class)
     public ContentBody<List<ErrorBindings>> handle(InvalidRequestParameterException e) {
-        LOG.warn("Invalid request parameters: {}", e);
+        LOG.error("유효하지 않은 요청입니다: {}", e);
         return new ContentBody<>(400, "Bad request.", "", e.getErrors());
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,5 +44,8 @@ logging:
 
 jwt:
   secret: ${jwt.secret}
-  expiration-ms: 3600000 # 1시간
-  refresh-expiration-ms: 604800000 # 7일
+  token:
+    access:
+      expiration-ms: 3600000 # 1시간
+    refresh:
+      expiration-ms: 604800000 # 7일

--- a/src/test/java/org/ccs/app/core/user/domain/UserAccountTest.java
+++ b/src/test/java/org/ccs/app/core/user/domain/UserAccountTest.java
@@ -1,0 +1,31 @@
+package org.ccs.app.core.user.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserAccountTest {
+
+    @Test
+    void test_confirm_password() {
+        String expected = "password!234";
+        LocalDateTime now = LocalDateTime.now();
+        UserAccount account = UserAccount.builder()
+                .loginFailureCount(0)
+                .lastAccessAt(now)
+                .status(AccountStatus.ENABLED)
+                .password("password!234")
+                .build();
+
+        account.confirmPassword("password!234");
+
+        assertAll(
+                () -> assertEquals(0, account.getLoginFailureCount()),
+                () -> assertNotEquals(now, account.getLastAccessAt())
+        );
+
+        // TODO : 숙제 - 비밀번호가 틀린 경우에 대한 테스트 코드를 짜보세요.
+    }
+}


### PR DESCRIPTION
## 변경 내용 요약

1. **LoginService 리팩토링:** `authenticate` 및 `createRefreshToken` 메서드에서 중복된 User 계정 조회 부분을 별도의 private 메서드로 분리하여 중복 제거.

2. **JwtTokenProvider 설정 변경:** `application.yml`에서 Jwt 토큰의 만료 시간 구성을 변경하고, 해당 설정을 사용하는 JwtTokenProvider 코드도 수정.

3. **JwtTokenProvider 코드 리팩토링:** Jwt 토큰 생성 중 중복 코드를 `generateTokenBase` 메서드로 추출하여 코드 재사용성 증대.

4. **BaseRestControllerAdvisor 로그 메세지 수정:** `BaseRestControllerAdvisor` 클래스의 로그 레벨과 메세지를 수정.