### PR TITLE
enum Role 다국어 적용

### DIFF
--- a/src/main/java/org/ccs/app/core/user/domain/Role.java
+++ b/src/main/java/org/ccs/app/core/user/domain/Role.java
@@ -1,6 +1,17 @@
 package org.ccs.app.core.user.domain;
 
+import java.util.Locale;
+import java.util.ResourceBundle;
+
 public enum Role {
-    // TODO: display name / 다국어 적용
-    ADMIN, STAFF, CHIEF, OFFICER, MANAGER, TEACHER,
+    ADMIN, STAFF, CHIEF, OFFICER, MANAGER, TEACHER;
+
+    public String getDisplayName(Locale locale) {
+        return Role.getDisplayNameForRole(this, locale);
+    }
+
+    private static String getDisplayNameForRole(Role role, Locale locale) {
+        ResourceBundle messages = ResourceBundle.getBundle("RoleMessages", locale);
+        return messages.getString(role.name());
+    }
 }

--- a/src/main/resources/properties/RoleMessages_en.properties
+++ b/src/main/resources/properties/RoleMessages_en.properties
@@ -1,0 +1,6 @@
+ADMIN=Administrator
+STAFF=Staff
+CHIEF=Chief
+OFFICER=Officer
+MANAGER=Manager
+TEACHER=Teacher

--- a/src/main/resources/properties/RoleMessages_ko.properties
+++ b/src/main/resources/properties/RoleMessages_ko.properties
@@ -1,0 +1,6 @@
+ADMIN=관리자
+STAFF=직원
+CHIEF=최고 책임자
+OFFICER=관리자
+MANAGER=매니저
+TEACHER=선생님


### PR DESCRIPTION
- 각 직급별 한글 명칭 재정의 필요합니다.