### PR TITLE
refactor: sendAccessDeniedResponse 메서드를 통한 ContentBody 직렬화

### DIFF
--- a/src/main/java/org/ccs/app/core/share/authenticate/AuthenticateHolder.java
+++ b/src/main/java/org/ccs/app/core/share/authenticate/AuthenticateHolder.java
@@ -7,7 +7,7 @@ public class AuthenticateHolder {
         authenticateHolder.set(authenticate);
     }
 
-    public static Authenticate getLoginUser() {
+    public static Authenticate get() {
         return authenticateHolder.get();
     }
 

--- a/src/main/java/org/ccs/app/entrypoints/share/filter/AdminContextFilter.java
+++ b/src/main/java/org/ccs/app/entrypoints/share/filter/AdminContextFilter.java
@@ -17,7 +17,7 @@ public class AdminContextFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 
-        Authenticate authenticate = AuthenticateHolder.getLoginUser();
+        Authenticate authenticate = AuthenticateHolder.get();
 
         if (hasAdminRole(authenticate)) {
             chain.doFilter(request, response);

--- a/src/main/java/org/ccs/app/entrypoints/share/filter/AdminContextFilter.java
+++ b/src/main/java/org/ccs/app/entrypoints/share/filter/AdminContextFilter.java
@@ -14,16 +14,25 @@ import java.io.IOException;
 @Order(31)
 public class AdminContextFilter implements Filter {
 
-    Authenticate authenticate = AuthenticateHolder.getLoginUser();
-
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        if (authenticate != null && authenticate.getRoles().contains(Role.ADMIN)) {
+
+        Authenticate authenticate = AuthenticateHolder.getLoginUser();
+
+        if (hasAdminRole(authenticate)) {
             chain.doFilter(request, response);
-        }else { // ADMIN 권한이 없는 경우
-            HttpServletResponse httpResponse = (HttpServletResponse) response;
-            httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
-            httpResponse.getWriter().write("Access Denied: Insufficient Permissions");
+        } else {
+            sendAccessDeniedResponse(response);
         }
+    }
+
+    private boolean hasAdminRole(Authenticate authenticate) {
+        return authenticate != null && authenticate.getRoles().contains(Role.ADMIN);
+    }
+
+    private void sendAccessDeniedResponse(ServletResponse response) throws IOException {
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        httpResponse.getWriter().write("Access Denied: Insufficient Permissions");
     }
 }

--- a/src/main/java/org/ccs/app/entrypoints/share/filter/AdminContextFilter.java
+++ b/src/main/java/org/ccs/app/entrypoints/share/filter/AdminContextFilter.java
@@ -2,6 +2,10 @@ package org.ccs.app.entrypoints.share.filter;
 
 import jakarta.servlet.*;
 import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import org.ccs.app.core.share.authenticate.Authenticate;
+import org.ccs.app.core.share.authenticate.AuthenticateHolder;
+import org.ccs.app.core.user.domain.Role;
 import org.springframework.core.annotation.Order;
 
 import java.io.IOException;
@@ -10,11 +14,16 @@ import java.io.IOException;
 @Order(31)
 public class AdminContextFilter implements Filter {
 
-    // TODO: 로직을 작성하세요.
-    // 힌트 : threadlocal 에 담겨있는 authenticate 객체를 활용하면 됩니다. 거기서 role 정보를 꺼내서 확인하세요.
+    Authenticate authenticate = AuthenticateHolder.getLoginUser();
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        chain.doFilter(request, response);
+        if (authenticate != null && authenticate.getRoles().contains(Role.ADMIN)) {
+            chain.doFilter(request, response);
+        }else { // ADMIN 권한이 없는 경우
+            HttpServletResponse httpResponse = (HttpServletResponse) response;
+            httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
+            httpResponse.getWriter().write("Access Denied: Insufficient Permissions");
+        }
     }
 }

--- a/src/main/java/org/ccs/app/entrypoints/share/filter/AdminContextFilter.java
+++ b/src/main/java/org/ccs/app/entrypoints/share/filter/AdminContextFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.ccs.app.core.share.authenticate.Authenticate;
 import org.ccs.app.core.share.authenticate.AuthenticateHolder;
 import org.ccs.app.core.user.domain.Role;
+import org.ccs.app.entrypoints.share.model.ContentBody;
 import org.springframework.core.annotation.Order;
 
 import java.io.IOException;
@@ -32,7 +33,15 @@ public class AdminContextFilter implements Filter {
 
     private void sendAccessDeniedResponse(ServletResponse response) throws IOException {
         HttpServletResponse httpResponse = (HttpServletResponse) response;
-        httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
-        httpResponse.getWriter().write("Access Denied: Insufficient Permissions");
+
+        ContentBody<String> accessDeniedBody = new ContentBody<>(
+                HttpServletResponse.SC_FORBIDDEN,
+                "Access Denied: 관리자 권한이 필요합니다.",
+                "",
+                null);
+
+        String serializedBody = ContentBody.serialize(accessDeniedBody);
+        httpResponse.setContentType("application/json");
+        httpResponse.getWriter().write(serializedBody);
     }
 }

--- a/src/main/java/org/ccs/app/entrypoints/share/filter/AdminContextFilter.java
+++ b/src/main/java/org/ccs/app/entrypoints/share/filter/AdminContextFilter.java
@@ -19,11 +19,11 @@ public class AdminContextFilter implements Filter {
 
         Authenticate authenticate = AuthenticateHolder.get();
 
-        if (hasAdminRole(authenticate)) {
-            chain.doFilter(request, response);
-        } else {
+        if (!hasAdminRole(authenticate)) {
             sendAccessDeniedResponse(response);
         }
+
+        chain.doFilter(request, response);
     }
 
     private boolean hasAdminRole(Authenticate authenticate) {

--- a/src/main/java/org/ccs/app/entrypoints/share/model/ContentBody.java
+++ b/src/main/java/org/ccs/app/entrypoints/share/model/ContentBody.java
@@ -1,20 +1,21 @@
 package org.ccs.app.entrypoints.share.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.ToString;
 
-//TODO: record 로 전환하기
-@Getter @ToString
-public class ContentBody<T> {
-    private final int code;
-    private final String message;
-    private final String traceId;
-    private final T contents;
+import java.io.IOException;
 
-    public ContentBody(int code, String message, String traceId, T contents) {
-        this.code = code;
-        this.message = message;
-        this.traceId = traceId;
-        this.contents = contents;
+@Getter
+@ToString
+public record ContentBody<T>(int code, String message, String traceId, T contents) {
+
+    public static <T> String serialize(ContentBody<T> contentBody) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        // Include non-null values only in the serialized output
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        return objectMapper.writeValueAsString(contentBody);
     }
 }

--- a/src/main/java/org/ccs/app/entrypoints/share/model/PageBody.java
+++ b/src/main/java/org/ccs/app/entrypoints/share/model/PageBody.java
@@ -4,13 +4,14 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter @ToString
-public class PageBody<T> extends ContentBody<T> {
+public class PageBody<T> {
+    private final ContentBody<T> contentBody;
     private final Long totalContent;
     private final Boolean prev;
     private final Boolean next;
 
     public PageBody(int code, String message, String traceId, T contents, Long totalContent, Boolean prev, Boolean next) {
-        super(code, message, traceId, contents);
+        this.contentBody = new ContentBody<>(code, message, traceId, contents);
         this.totalContent = totalContent;
         this.next = next;
         this.prev = prev;


### PR DESCRIPTION
## 내용
- ContentBody.java Record 변환
- PageBody.java 내에 ContentBody<T> 타입의 contentBody 필드를 추가하고 활용하도록 변경하였습니다.
- sendAccessDeniedResponse 메서드 업데이트, serialize 메서드를 사용하여 ContentBody를 직렬화하도록 수정