### PR TITLE
Errorcode 다국어 적용하기

### DIFF
--- a/src/main/java/org/ccs/app/core/share/exception/ErrorCode.java
+++ b/src/main/java/org/ccs/app/core/share/exception/ErrorCode.java
@@ -11,23 +11,28 @@ import lombok.Getter;
  */
 public enum ErrorCode {
     // TODO : message 에 다국어 적용
-    UNKNOWN(100, ""),
+    UNKNOWN(100, "", ""),
 
-    UNAUTHORIZED_ACCESS(101, "사용자 인증에 실패하였습니다."),
-    NO_SUCH_USER(102, "로그인 아이디를 찾을 수 없습니다."),
-    INCORRECT_PASSWORD(102, "로그인 패스워드가 일치하지 않습니다."),
+    UNAUTHORIZED_ACCESS(101, "사용자 인증에 실패하였습니다.", "Authentication failure."),
+    NO_SUCH_USER(102, "로그인 아이디를 찾을 수 없습니다.", "Login ID not found."),
+    INCORRECT_PASSWORD(103, "로그인 패스워드가 일치하지 않습니다.", "Incorrect login password."),
 
-    NOT_FOUND_MENU(1000, ""),
+    NOT_FOUND_MENU(1000, "", ""),
     ;
 
     @Getter
     int code;
 
     @Getter
-    String message;
+    String koMessage;
 
-    ErrorCode(int code, String message) {
+    @Getter
+    String enMessage;
+
+
+    ErrorCode(int code, String koMessage, String enMessage) {
         this.code = code;
-        this.message = message;
+        this.koMessage = koMessage;
+        this.enMessage = enMessage;
     }
 }

--- a/src/main/java/org/ccs/app/core/share/exception/ErrorCode.java
+++ b/src/main/java/org/ccs/app/core/share/exception/ErrorCode.java
@@ -2,6 +2,9 @@ package org.ccs.app.core.share.exception;
 
 import lombok.Getter;
 
+import java.util.Locale;
+import java.util.ResourceBundle;
+
 /**
  * Error Code 정리
  *  공용      : SHARE  (0-999)
@@ -10,29 +13,27 @@ import lombok.Getter;
  *  (계속추가)
  */
 public enum ErrorCode {
-    // TODO : message 에 다국어 적용
-    UNKNOWN(100, "", ""),
-
-    UNAUTHORIZED_ACCESS(101, "사용자 인증에 실패하였습니다.", "Authentication failure."),
-    NO_SUCH_USER(102, "로그인 아이디를 찾을 수 없습니다.", "Login ID not found."),
-    INCORRECT_PASSWORD(103, "로그인 패스워드가 일치하지 않습니다.", "Incorrect login password."),
-
-    NOT_FOUND_MENU(1000, "", ""),
+    UNKNOWN(100, "UNKNOWN"),
+    UNAUTHORIZED_ACCESS(101, "UNAUTHORIZED_ACCESS"),
+    NO_SUCH_USER(102, "NO_SUCH_USER"),
+    INCORRECT_PASSWORD(103, "INCORRECT_PASSWORD"),
+    NOT_FOUND_MENU(1000, "NOT_FOUND_MENU")
     ;
 
     @Getter
     int code;
 
     @Getter
-    String koMessage;
-
-    @Getter
-    String enMessage;
+    String message;
 
 
-    ErrorCode(int code, String koMessage, String enMessage) {
+    ErrorCode(int code, String message) {
         this.code = code;
-        this.koMessage = koMessage;
-        this.enMessage = enMessage;
+        this.message = message;
+    }
+
+    public String getMessage(Locale locale) {
+        ResourceBundle bundle = ResourceBundle.getBundle("errorMessages", locale);
+        return bundle.getString(message);
     }
 }

--- a/src/main/resources/properties/errorMessages_en.properties
+++ b/src/main/resources/properties/errorMessages_en.properties
@@ -1,0 +1,5 @@
+UNKNOWN=Unknown error occurred.
+UNAUTHORIZED_ACCESS=Authentication failure.
+NO_SUCH_USER=Login ID not found.
+INCORRECT_PASSWORD=Incorrect login password.
+NOT_FOUND_MENU=Menu not found.

--- a/src/main/resources/properties/errorMessages_ko.properties
+++ b/src/main/resources/properties/errorMessages_ko.properties
@@ -1,0 +1,5 @@
+UNKNOWN=알 수 없는 오류가 발생했습니다.
+UNAUTHORIZED_ACCESS=사용자 인증에 실패하였습니다.
+NO_SUCH_USER=로그인 아이디를 찾을 수 없습니다.
+INCORRECT_PASSWORD=로그인 패스워드가 일치하지 않습니다.
+NOT_FOUND_MENU=메뉴를 찾을 수 없습니다.


### PR DESCRIPTION
### 내용
- enum 클래스인 ErrorCode에 다국어 적용
- `v1` = properties 미사용, `v2` = properties 사용입니다.